### PR TITLE
DOCS-4 - Change build dependencies from yarn to npm

### DIFF
--- a/.github/workflows/deploy-v2-4-3.yml
+++ b/.github/workflows/deploy-v2-4-3.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: yarn
+          cache: npm
           cache-dependency-path: ./package-lock.json
 
       - name: Set SSH for remote host as private key in pem format 
@@ -33,8 +33,11 @@ jobs:
         env:
           USE_SSH: true
         run: |
+          echo "Configure git settings"
           git config --global user.email "crexroth@metrohealth.org"
           git config --global user.name "crexroth"
-          yarn install --frozen-lockfile
-          yarn deploy
+          echo "Install dependencies (clean install) based on package-lock.json"
+          npm ci
+          echo "Build and deploy site to COSMIIC-Inc.github.io"
+          npm run deploy
           

--- a/.github/workflows/test-deploy-v2-4-3.yml
+++ b/.github/workflows/test-deploy-v2-4-3.yml
@@ -1,4 +1,4 @@
-name: Test deployment
+name: Test build on pull request
 
 on:
   pull_request:
@@ -11,16 +11,20 @@ permissions:
 
 jobs:
   test-deploy:
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Checkout the source repo
+        uses: actions/checkout@v3
+
+      - name: Set up node.js
+        uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: yarn
+          cache: npm
           cache-dependency-path: ./package-lock.json
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-      - name: Test build website
-        run: yarn build
+      - name: Install dependencies (clean install) based on package-lock.json
+        run: npm ci
+      - name: Build site on test client
+        run: npm run build
  


### PR DESCRIPTION
Changes: 
1. The javascript package manager was changed from ```yarn``` to ```npm```. 
2. Using ```ci``` meaning a 'clean install' that uses version specific dependencies
3. Added ```echo``` statements to describe commands in ```:run``` of deploy yaml

Reasons:
1. I was using ```yarn``` because the commands are simplified and it was recommended in the ```docusaurus``` tutorials, but ```npm``` seems to be more of a current day standard and better fits open source aspects.
2. Makes sure the build is conducted the same way every time and avoids discrepancies between automatically chosen dependency versions. This is the standard for conducting these types of automatic builds on remote clients
3. Comments will show in GitHub command prompt now