### PR TITLE
DOCS-14 - Eliminate skipped tests showing up in builds

### DIFF
--- a/.github/workflows/deploy-v2-4-3.yml
+++ b/.github/workflows/deploy-v2-4-3.yml
@@ -1,8 +1,6 @@
 name: Deploy to GitHub Pages
 
 on:
-  pull_request:
-    branches: [main]
   push:
     branches: [main]
 
@@ -11,7 +9,6 @@ permissions:
 
 jobs:
   deploy:
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source repo

--- a/.github/workflows/test-deploy-v2-4-3.yml
+++ b/.github/workflows/test-deploy-v2-4-3.yml
@@ -3,15 +3,12 @@ name: Test build on pull request
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 permissions:
   contents: write
 
 jobs:
   test-deploy:
-    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source repo


### PR DESCRIPTION
Removed on: selector for push: from test-deploy and pull_request: from deploy along with corresponding `if` statements meant for a combined file. 

Trying to decide if it is better to have two separate test files or not. Will see how it appears on this pull request.