### PR TITLE
DOCS-16 - Add video playback feature

### DIFF
--- a/docs/FAQ-Support.mdx
+++ b/docs/FAQ-Support.mdx
@@ -11,7 +11,7 @@ Posters, videos, and frequently asked questions (FAQs)
 ---
 
 <div class='youtube-player'>
-    <ReactPlayer controls url='https://youtu.be/vmd1qMN5Yo0?si=jLwZ9bABRtVsS9ga' />
+    <ReactPlayer controls url='https://youtu.be/iR8SAETKZVs?si=0-7DH17_TGJ2O7uC' />
 </div>
 
 <p></p>

--- a/docs/FAQ-Support.mdx
+++ b/docs/FAQ-Support.mdx
@@ -2,11 +2,19 @@
 sidebar_position: 8
 ---
 
-# FAQ & Support
+import ReactPlayer from 'react-player'
 
-Frequently Asked Questions + other guidance
+# Resources & FAQ
+
+Posters, videos, and frequently asked questions (FAQs)
 
 ---
+
+<div class='youtube-player'>
+    <ReactPlayer controls url='https://youtu.be/vmd1qMN5Yo0?si=jLwZ9bABRtVsS9ga' />
+</div>
+
+<p></p>
 
 :::tip How can I obtain documents for my research group before COSMIIC releases all documentation?
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "clsx": "^1.2.1",
         "prism-react-renderer": "^1.3.5",
         "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react-dom": "^17.0.2",
+        "react-player": "^2.13.0"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "2.4.3"
@@ -7796,6 +7797,11 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "node_modules/load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -8029,6 +8035,11 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -9834,6 +9845,21 @@
       "peerDependencies": {
         "react-loadable": "*",
         "webpack": ">=4.41.1 || 5.x"
+      }
+    },
+    "node_modules/react-player": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.13.0.tgz",
+      "integrity": "sha512-gkY7ZdbVFztlKFFhCPcnDrFQm+L399b8fhWsKatZ+b2wpKJwfUHBXQFMRxqYQGT0ic1/wQ7D7EZEWy7ZBqk2pw==",
+      "dependencies": {
+        "deepmerge": "^4.0.0",
+        "load-script": "^1.0.0",
+        "memoize-one": "^5.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
       }
     },
     "node_modules/react-router": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "react-player": "^2.13.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.4.3"

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -30,3 +30,8 @@
   --ifm-link-color: #0C6F6E;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
+
+/** Styling for centering resource videos from Youtube with the react-player module. May need to adjust for mobile */
+.youtube-player {
+  padding-left: 16%;
+}


### PR DESCRIPTION
React-player is a tool that can play files or Youtube links with a page-embedded player. 

The package is added to the build tool through the package-lock.json file and is called in the FAQ-Support.md page which I figure can hold a small amount of resources before necessitating a full Resources page. 

I gave the react player its own styling class specific for Youtube videos to center it on the page crudely.