### PR TITLE
DOCS-25 - Implement site mapping

### DIFF
--- a/docs/Software.md
+++ b/docs/Software.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Software
 
-The tower that controls the Power Module
+The brains of the operation
 
 ---
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -47,6 +47,13 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+
+        sitemap: {
+          changefreq: 'weekly',
+          priority: 0.5,
+          ignorePatterns: ['/tags/**'],
+          filename: 'sitemap.xml',
+        },
       }),
     ],
   ],


### PR DESCRIPTION
An easy accept fyi

Site will now have metadata including a site map, which will help it be picked up by search engines better, for the home page and other sub-pages as well. Will have to wait and see final deployment to confirm the map is present (the site map is only generated for the final build)