### PR TITLE
DOCS-24 - Implement Google Tag Manager

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -47,7 +47,13 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
-
+        gtag: {
+          trackingID: 'G-3R659EMH3F',
+          anonymizeIP: true,
+        },
+        googleTagManager: {
+          containerId: 'GTM-N9WVB6FP',
+        },
         sitemap: {
           changefreq: 'weekly',
           priority: 0.5,


### PR DESCRIPTION
Adding two plugins: gtag (basic) and googleTagManager (more features)

We'll see if this works. I made the googleTagManager container pre-emptively for the docs.cosmiic.org without copying any of the Google code in because I'm hoping the plug-in will generate it for the site and then they will show on Google.

gtag couldn't create an ID for docs.cosmiic.org, so I input the trackingID for cosmiic.org